### PR TITLE
pyo3: 可选依赖

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target/
 Cargo.lock
 models/
+.envrc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "bili_ticket_gt_python"
 version = "0.3.2"
 edition = "2024"
 
+[features]
+default = ["pyo3"]
+
 [lib]
 name = "bili_ticket_gt_python"
 crate-type = ["cdylib"]
@@ -12,9 +15,8 @@ reqwest = {version = "0.12", features = ["blocking", "json"]}
 serde = "1.0"
 serde_json = "1.0"
 image = "0.25"
-pyo3 = { version = "0.23.5", features = ["auto-initialize", "extension-module"]}
+pyo3 = { version = "0.23.5", features = ["auto-initialize", "extension-module"], optional = true }
 captcha_breaker = "0.0.0-dev.7"
-
 
 rsa = "0.9"
 rand = "0.8.5"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1746576598,
+        "narHash": "sha256-FshoQvr6Aor5SnORVvh/ZdJ1Sa2U4ZrIMwKBX5k2wu0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b3582c75c7f21ce0b429898980eddbbf05c68e55",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1746758179,
+        "narHash": "sha256-JECUw1YBEsTsVauvupRzE5ykZaJoyhHCpoY87ZZJGas=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "4fd00513eac6b6140c5dced3e1b8133e2369a0f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+{
+  description = "Rust Shell";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs =
+    {
+      self,
+      flake-utils,
+      nixpkgs,
+      rust-overlay,
+      ...
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        overlays = [
+          rust-overlay.overlays.default
+          (final: prev: {
+            rustToolchain =
+              let
+                rust = prev.rust-bin;
+              in
+              if builtins.pathExists ./rust-toolchain.toml then
+                rust.fromRustupToolchainFile ./rust-toolchain.toml
+              else if builtins.pathExists ./rust-toolchain then
+                rust.fromRustupToolchainFile ./rust-toolchain
+              else
+                rust.stable."1.86.0".default.override {
+                  extensions = [
+                    "rust-src"
+                    "rustfmt"
+                    "rust-analyzer"
+                    "clippy"
+                    "cargo"
+                  ];
+                  targets = [
+                    "wasm32-unknown-unknown"
+                    "wasm32-wasip1"
+                  ];
+                };
+          })
+        ];
+        pkgs = import nixpkgs { inherit overlays system; };
+      in
+      {
+        devShells.default =
+          with pkgs;
+          mkShell rec {
+            packages = [
+              pkg-config
+              openssl
+              rustToolchain
+            ];
+
+            env = {
+              CARGO_HOME = builtins.toString ".cargo";
+              RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
+            };
+
+            shellHook = ''
+              export PATH="$PWD/${env.CARGO_HOME}/bin:$PATH"
+            '';
+          };
+      }
+    );
+}


### PR DESCRIPTION
只在rust内引用时用不到, 留个余地不依赖pyo3
（其实是为了最大可能地构建到wasm）